### PR TITLE
fix bug caused by protection against host header injection

### DIFF
--- a/gd_node/protocols/http/middleware.py
+++ b/gd_node/protocols/http/middleware.py
@@ -61,7 +61,7 @@ class JWTMiddleware:
         ):
             # contains non-ascii chars
             return False
-        if bleach.clean(str(request.raw_headers)) != str(request.raw_headers):
+        if bleach.clean(str(request.headers['Host'])) != str(request.headers['Host']):
             return False
         decoded_params = urllib.parse.unquote(q_string)
         if "<script>" in decoded_params:


### PR DESCRIPTION
The header injection protection was updated to check only the host header instead of the request all headers.
The former solution caused a bug in the _is_safe() function which made some of the request unsafe.

jira:
https://movai.atlassian.net/browse/BP-827?atlOrigin=eyJpIjoiOWIyZmU5OGNlMzM2NDQ1MWJhNDNkMTRkYTFiOTY1ODEiLCJwIjoiaiJ9


old jira ticket for host header injection:
https://movai.atlassian.net/browse/BP-689

old fix:
https://github.com/MOV-AI/movai_classes/tree/bugfix/BP-689/Host_Header_Injection

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
'- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue'


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
