### PR TITLE
BP-568: add support for sending params to Ros1Publisher

### DIFF
--- a/gd_node/protocols/ros1.py
+++ b/gd_node/protocols/ros1.py
@@ -537,11 +537,15 @@ class ROS1_Publisher:
         _message: ROS message
     """
 
-    def __init__(self, _topic: str, _message: Any) -> None:
+    def __init__(self, _topic: str, _message: Any, _params: dict) -> None:
         """Init"""
 
         self.msg = GD_Message(_message).get()
-        self.pub = rospy.Publisher(_topic, self.msg, queue_size=1)
+        params = {
+            "queue_size": 1
+        }
+        params.update(_params)
+        self.pub = rospy.Publisher(_topic, self.msg, **params)
 
     def send(self, msg: Any) -> None:
         """Send function


### PR DESCRIPTION
- [BP-568](https://movai.atlassian.net/browse/BP-568): Support for sending latched topic in gd.oport api

[BP-568]: https://movai.atlassian.net/browse/BP-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ