### PR TITLE
correct the import of the package

### DIFF
--- a/gd_node/callback.py
+++ b/gd_node/callback.py
@@ -25,7 +25,7 @@ from dal.models.callback import Callback
 from dal.models.lock import Lock
 from dal.models.container import Container
 from dal.models.nodeinst import NodeInst
-from dal.models.package import Package
+from dal.scopes.package import Package
 from dal.models.ports import Ports
 from dal.models.var import Var
 from dal.models.scopestree import ScopesTree, scopes


### PR DESCRIPTION
- [BP-996](https://movai.atlassian.net/browse/BP-996): Not possible to upload assets to Package
    - The package model was imported from the new models 
      while the classes repo imported from the deprecated dir (inherit from scopes)
      
      And while running the `Package.add()` function it raises `NotImplementedError`
      
      as we can see:
      https://github.com/MOV-AI/data-access-layer/blob/feature/BP-255/intergrating-the-spawner/dal/models/package.py#L41
      
      in the new model (inherit from the model) this function raises this exception 



[BP-996]: https://movai.atlassian.net/browse/BP-996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ