### PR TITLE
added a loop that will wait for node to finish init

### DIFF
--- a/gd_node/protocols/ros1.py
+++ b/gd_node/protocols/ros1.py
@@ -15,6 +15,8 @@ import os
 import sys
 from typing import Any
 
+from rospy.timer import sleep
+
 import actionlib
 import rosgraph
 import rosnode
@@ -119,12 +121,16 @@ class ROS1IportBase(BaseIport):
     """
     A base class for all of the ROS IPORTS
     """
+    MAX_RETRIES = 100
 
-    def __init__(self, _node_name: str, _port_name: str, _topic: str, _message: str, _callback: str, _update: bool, **_):
-        """Init"""
-        super().__init__(_node_name, _port_name, _topic, _message, _callback, _update)
-        self.enabled = True
-
+    def callback(self, msg: Any) -> None:
+        """Callback function for all the ROS IPORTS"""
+        for _ in range(self.MAX_RETRIES):
+            if self.enabled:
+                self.cb.execute(msg)
+                return
+            # if the port isn't initiated after 10 seconds it means it's disabled
+            sleep(0.1)
 
 class ROS1_Subscriber(ROS1IportBase):
 

--- a/gd_node/protocols/ros1.py
+++ b/gd_node/protocols/ros1.py
@@ -15,8 +15,6 @@ import os
 import sys
 from typing import Any
 
-from rospy.timer import sleep
-
 import actionlib
 import rosgraph
 import rosnode
@@ -130,7 +128,7 @@ class ROS1IportBase(BaseIport):
                 self.cb.execute(msg)
                 return
             # if the port isn't initiated after 10 seconds it means it's disabled
-            sleep(0.1)
+            rospy.timer.sleep(0.1)
 
 class ROS1_Subscriber(ROS1IportBase):
 

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,12 @@ with open("README.md", "r") as fh:
 requirements = [
     "aiohttp==3.8.1",
     "aiohttp_cors==0.7.0",
-    "aioredis==1.3.1",
     "bleach==4.1.0",
-    "requests==2.28.2",
     "uvloop==0.14.0",
-    "data-access-layer>=2.4.1.35",
+    "data-access-layer==2.4.1.*",
 ]
+# requests is required movai-core-shared
+# aioredis is required by data-access-layer
 
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     "uvloop==0.14.0",
     "data-access-layer==2.4.1.*",
 ]
-# requests is required movai-core-shared
+# requests is required by movai-core-shared
 # aioredis is required by data-access-layer
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     "bleach==4.1.0",
     "requests==2.28.2",
     "uvloop==0.14.0",
-    "data-access-layer==2.4.1.*",
+    "data-access-layer>=2.4.1.35",
 ]
 
 


### PR DESCRIPTION
There is a timing problem 
that the ros nodes need time to init
and then the node sleep for 0.2 sec, and give time the ros ports to init
and only after this, the node can init, and can start the init callback that start with the init port (movai protocol)
and then we enable the ports, and let the callbacks start

but this caused a problem with the latched messages
So now I changed the code so that the callback will wait for the port to be enabled 
That only will happen after the init 
and we will not miss the latched message
