### PR TITLE
Ver 2.4.1.20

### DIFF
--- a/gd_node/callback.py
+++ b/gd_node/callback.py
@@ -137,7 +137,7 @@ class GD_Callback:
                     f"{self.node_name}/{self.port_name}/{self.callback.Label} took: {t_delta}"
                 )
         except TransitionException:
-            LOGGER.info("Transitioning...")
+            LOGGER.debug("Transitioning...")
         except Exception as e:
             LOGGER.error(str(e), node=self.node_name, callback=self.name)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [
     "aiohttp_cors==0.7.0",
     "aioredis==1.3.1",
     "bleach==4.1.0",
-    "requests==2.22.0",
+    "requests==2.28.2",
     "uvloop==0.14.0",
     "data-access-layer==2.4.1.*",
 ]


### PR DESCRIPTION
 - [BP-330](https://movai.atlassian.net/browse/BP-330): [spawner][logs] remove redundant logs when transitioning between states:
     - Changed the verbosity from info to debug, see comments in the jira ticket
 -  [BP-994](https://movai.atlassian.net/browse/BP-994): State Node port callbacks called after transitioning
 

[BP-330]: https://movai.atlassian.net/browse/BP-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BP-994]: https://movai.atlassian.net/browse/BP-994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ