### PR TITLE
revert killing the node on callback errors

### DIFF
--- a/gd_node/callback.py
+++ b/gd_node/callback.py
@@ -149,7 +149,8 @@ class GD_Callback:
             sys.exit(1)
         except Exception as e:
             LOGGER.error(f"Error in executing callback. Node: {self.node_name} Callback: {self.name}", exc_info=True)
-            sys.exit(1)
+            #TODO We can't kill the node if callbacks blow up. Some callbacks are not critical.
+            #sys.exit(1)
 
 
 
@@ -183,7 +184,8 @@ class UserFunctions:
                 raise CancelledError("cancelled task")
             except (ImportError, AttributeError, LookupError):
                 LOGGER.error(f"Import {lib} in callback blew up. Node: {self.node_name} Callback: {self.cb_name}", exc_info=True)
-                sys.exit(1)
+                #TODO We can't kill the node if callbacks blow up. Some callbacks are not critical.
+                #sys.exit(1)
 
         if GD_Callback._robot is None:
             GD_Callback._robot = Robot()


### PR DESCRIPTION
Some nodes are raising an exception in the callback and the node was being killed.  Example:
![image](https://github.com/MOV-AI/gd-node/assets/93730683/3594f76f-e3ae-428a-9f7f-7ade48149f74)
The node of the ungrab would die, and the robot would get not finish the drop procedure.

I will revert the killing of the node because this can affect the stability of the long runs. But we should consider in the future bringing back this killing of the nodes and fixing the callbacks that have exceptions