### PR TITLE
BP-1258: Explicitly connect to Redis

### DIFF
--- a/gd_node/node.py
+++ b/gd_node/node.py
@@ -20,7 +20,7 @@ from movai_core_shared.logger import Log
 from movai_core_shared.consts import MOVAI_INIT, MOVAI_TRANSITION, MOVAI_CONTEXTCLIENTIN
 
 # importing database profile automatically registers the database connections
-from dal.movaidb import RedisClient
+from dal.movaidb import RedisClient, MovaiDB
 from dal.models.scopestree import scopes, ScopePropertyNode
 from dal.models.var import Var
 
@@ -77,8 +77,11 @@ class GDNode:
 
     async def connect(self) -> None:
         """Connect to aioredis slave db"""
+        # for subscribing to events
         self.databases = await RedisClient.get_client()
-        # await self.databases.init_redis()
+        # for reading/writing
+        #MovaiDB("global")
+        #MovaiDB("local")
 
     def _stop(self):
         """stop node out of async loop"""


### PR DESCRIPTION
As was described in earlier PRs, the automatic connection to Redis upon import of some modules was fixed. This means some code that implicitly relied on this behavior stopped working. This fixes the error on the GD Node.

Ticket: [BP-1258](https://movai.atlassian.net/browse/BP-1258)

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
~[ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue~ (Tested locally using qa_platform_sanity_tests)


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository


[BP-1258]: https://movai.atlassian.net/browse/BP-1258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ