### PR TITLE
Document callback builtins

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,6 +13,7 @@ Welcome to GD Node's documentation!
 
    readme
    modules
+   using_gd_node
 
 .. include:: readme.rst
 

--- a/docs/source/using_gd_node.rst
+++ b/docs/source/using_gd_node.rst
@@ -1,0 +1,38 @@
+Using GD Node
+=============
+
+Callback builtins
+-----------------
+
+The GD Node callbacks have access to the following builtins:
+
+* ``scopes``: A ScopesTree **instance**
+* ``Package``: Package class
+* ``Message``: Message class
+* ``Ports``: Ports class
+* ``StateMachine``: StateMachine class
+* ``Var``: UserVar class - used to set, get and delete node scoped variables
+* ``Robot``: Robot class **instance**
+* ``FleetRobot``: FleetRobot class
+* ``logger``: LogAdapter **instance** - logger that should be used in callbacks
+* ``PortName``: Name of the port that triggered the callback
+* ``SM``:UserSM class
+* ``Callback``: Callback class
+* ``Lock``: UserLock class - used to interact with locks
+* ``print``: Debug log function
+* ``Scene``: Active scene **instance**, None if active_scene is not specified
+* ``NodeInst``: NodeInst class
+* ``Container``: Container class
+* ``Configuration``: Configuration class
+
+If you are using the enterprise version of MOV.AI the following are also available:
+
+* ``Alerts``: Alerts class
+* ``Annotation``: Annotation class
+* ``GraphicAsset``: GraphicAsset class
+* ``GraphicScene``: GraphicScene class
+* ``Layout``: Layout class
+* ``metrics``: Metrics class **instance**
+* ``Task``: Task class
+* ``TaskEntry``: TaskEntry class
+* ``TaskTemplate``: TaskTemplate class

--- a/docs/source/using_gd_node.rst
+++ b/docs/source/using_gd_node.rst
@@ -23,7 +23,7 @@ The GD Node callbacks have access to the following builtins:
 * ``run``: Function to run another callback (from the callback itself)
 * ``Scene``: Active scene **instance**, None if active_scene is not specified
 * ``scopes``: A ScopesTree **instance**
-* ``SM``:UserSM class
+* ``SM``: UserSM class
 * ``StateMachine``: StateMachine class
 * ``Var``: UserVar class - used to set, get and delete node scoped variables
 

--- a/docs/source/using_gd_node.rst
+++ b/docs/source/using_gd_node.rst
@@ -6,24 +6,26 @@ Callback builtins
 
 The GD Node callbacks have access to the following builtins:
 
-* ``scopes``: A ScopesTree **instance**
-* ``Package``: Package class
+* ``Callback``: Callback class
+* ``Configuration``: Configuration class
+* ``Container``: Container class
+* ``FleetRobot``: FleetRobot class
+* ``gd``: Node shared object - used to get param and interact with oports
+* ``Lock``: UserLock class - used to interact with locks
+* ``logger``: LogAdapter **instance** - logger that should be used in callbacks
 * ``Message``: Message class
+* ``NodeInst``: NodeInst class
+* ``Package``: Package class
+* ``PortName``: Name of the port that triggered the callback
 * ``Ports``: Ports class
+* ``print``: Debug log function
+* ``Robot``: Robot class **instance**
+* ``run``: Function to run another callback (from the callback itself)
+* ``Scene``: Active scene **instance**, None if active_scene is not specified
+* ``scopes``: A ScopesTree **instance**
+* ``SM``:UserSM class
 * ``StateMachine``: StateMachine class
 * ``Var``: UserVar class - used to set, get and delete node scoped variables
-* ``Robot``: Robot class **instance**
-* ``FleetRobot``: FleetRobot class
-* ``logger``: LogAdapter **instance** - logger that should be used in callbacks
-* ``PortName``: Name of the port that triggered the callback
-* ``SM``:UserSM class
-* ``Callback``: Callback class
-* ``Lock``: UserLock class - used to interact with locks
-* ``print``: Debug log function
-* ``Scene``: Active scene **instance**, None if active_scene is not specified
-* ``NodeInst``: NodeInst class
-* ``Container``: Container class
-* ``Configuration``: Configuration class
 
 If you are using the enterprise version of MOV.AI the following are also available:
 

--- a/docs/source/using_gd_node.rst
+++ b/docs/source/using_gd_node.rst
@@ -11,12 +11,33 @@ The GD Node callbacks have access to the following builtins:
 * ``Container``: Container class
 * ``FleetRobot``: FleetRobot class
 * ``gd``: Node shared object - used to get param and interact with oports
+
+   .. code-block:: python
+
+      # Get the value of a param
+      param_value = gd.params('param_name')
+
+      # Set the value of an oport
+      gd.oport('port_name').send(msg)
+
 * ``Lock``: UserLock class - used to interact with locks
+
+   .. code-block:: python
+
+      # Acquire a lock
+      Lock(Robot.RobotName, persistent=True).acquire()
+
 * ``logger``: LogAdapter **instance** - logger that should be used in callbacks
 * ``Message``: Message class
 * ``NodeInst``: NodeInst class
 * ``Package``: Package class
 * ``PortName``: Name of the port that triggered the callback
+
+   .. code-block:: python
+
+      # Log the name of the port that triggered the callback
+      logger.info("The callback was triggered by port: %s", PortName)
+
 * ``Ports``: Ports class
 * ``print``: Debug log function
 * ``Robot``: Robot class **instance**

--- a/docs/source/using_gd_node.rst
+++ b/docs/source/using_gd_node.rst
@@ -7,7 +7,7 @@ Callback builtins
 The GD Node callbacks have access to the following builtins:
 
 * ``Callback``: Callback class
-* ``Configuration``: Configuration class
+* ``Configuration``: Configuration class - used to get Configuration files
 * ``Container``: Container class
 * ``FleetRobot``: FleetRobot class
 * ``gd``: Node shared object - used to get param and interact with oports
@@ -34,7 +34,7 @@ If you are using the enterprise version of MOV.AI the following are also availab
 * ``GraphicAsset``: GraphicAsset class
 * ``GraphicScene``: GraphicScene class
 * ``Layout``: Layout class
-* ``metrics``: Metrics class **instance**
+* ``metrics``: Metrics class **instance** - used to send metrics
 * ``Task``: Task class
 * ``TaskEntry``: TaskEntry class
 * ``TaskTemplate``: TaskTemplate class


### PR DESCRIPTION
- [BP-1306](https://movai.atlassian.net/browse/BP-1306): Document GDNode callbacks builtins
  - I was looking forward for the outcomes not the documentation in it self, so I didn't put much effort in documenting each builtin
  - Outcomes:
    - Issues in the amount/scope of the builtins: some of the builtins can be removed, opened https://movai.atlassian.net/browse/BP-1307
    - Issues in uniformization: some of the builtins are class instances, other the class objects, without clear distinction in the casing of the builtin name (the builtin `Metrics` should be `metrics`)
    - The class design is a bit odd, which translates to even weirder robotics code `set([FleetRobot(robot_id).RobotName for robot_id in Robot.get_all()])` (taken from `traffic_warden.py`)

[BP-1306]: https://movai.atlassian.net/browse/BP-1306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ