### PR TITLE
BP-1322: Moved Var_Subscriber from DAL

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = "3.0.1-1"
+current_version = "3.0.1-0"
 commit = True
 message = 
 	[SKIP] Automatic version bump {current_version} -> {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = "3.0.0-2"
+current_version = "3.0.1-1"
 commit = True
 message = 
 	[SKIP] Automatic version bump {current_version} -> {new_version}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+# v3.0.1
+- [BP-1322](https://movai.atlassian.net/browse/BP-1322): Moved Var_Subscriber from DAL
+
 # v3.0.0 (same as v2.5.0.19)
 - [BP-1320](https://movai.atlassian.net/browse/BP-1315): Move development to main branch

--- a/gd_node/protocol.py
+++ b/gd_node/protocol.py
@@ -12,15 +12,13 @@
 """
 from typing import Any
 
-from dal.classes.protocols import redissub as RedisSub
-
+from gd_node.protocols import redissub as RedisSub
 import gd_node.protocols.http.http_route
 import gd_node.protocols.http.web_socket
 import gd_node.protocols.base as Base
 import gd_node.protocols.http as Http
 import gd_node.protocols.ros1 as ROS1
 import gd_node.protocols.movai as MovAI
-
 from gd_node.user import GD_User as gd
 
 

--- a/gd_node/protocols/redissub.py
+++ b/gd_node/protocols/redissub.py
@@ -1,0 +1,88 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Manuel Silva (manuel.silva@mov.ai) - 2020
+   - Tiago Paulino (tiago@mov.ai) - 2020
+
+   Module that implements Redis Subscriber as a GD_Node input protocol
+"""
+import asyncio
+from typing import Any
+
+from dal.movaidb import MovaiDB, RedisClient
+from dal.scopes.robot import Robot
+
+from gd_node.message import GD_Message
+from gd_node.protocols.base import BaseIport
+
+
+class Var_Subscriber(BaseIport):
+
+    """
+    Redis Var Event Subscriber. Implementention of redis pubsub
+
+    Args:
+        _node_name: Name of the node instance
+        _port_name:  Name of the port
+        _topic: Iport topic - not used
+        _message: Custom Message containing subscribed info
+        _callback: Name of the callback to be executed
+    """
+
+    def __init__(self, _node_name: str, _port_name: str, _topic: str,
+                 _message: str, _callback: str, _params: dict, _update: bool, **_ignore):
+        """Init
+        """
+        super().__init__(_node_name, _port_name, _topic, _message, _callback, _update)
+
+        self.msg = GD_Message('movai_msgs/redis_sub').get()
+        self.loop = asyncio.get_event_loop()
+
+        scopes = ['node', 'robot', 'fleet', 'global', 'flow']
+
+        var_type = _params.get('Type', 'Node').lower()
+        var_name = _params.get('Variable', '')
+
+        if var_type not in scopes:
+            raise Exception(
+                "'" + var_type + "' is not a valid scope. Choose between: " + str(scopes)[1:-1])
+
+        prefixes = {'node': _node_name + '@', 'robot': '@',
+                    'fleet': Robot().name + '@', 'global': '@', 'flow': 'flow@'}
+
+        prefix = prefixes.get(var_type, '@')
+
+        self.db = 'global' if var_type in ('fleet', 'global') else 'local'
+
+        sub_dict = {'Var': {var_type: {'ID': {prefix+var_name: {'Value': ''}}}}}
+
+        self.loop.create_task(self.register_sub(
+            self.db, self.loop, sub_dict, self.callback))
+
+    async def register_sub(self, db, loop, sub_dict, callback):
+        """Register the subscriber"""
+        databases = await RedisClient.get_client()
+        await MovaiDB(db=db, loop=loop, databases=databases).subscribe(sub_dict, callback)
+
+    def callback(self, msg: Any) -> None:
+        """Callback of the Redis subscriber protocol
+
+        Args:
+            msg: Redis psubscribe message
+        """
+        new_msg = self.msg()
+
+        operation = msg[1]
+        new_msg.type = operation
+        changed_key = msg[0].decode('utf-8').split(':', 1)
+        changed_dict = MovaiDB(self.db).keys_to_dict([(changed_key[1], '')])
+
+        if operation == 'del':
+            new_msg.data = None
+        elif operation == 'set':
+            new_msg.data = MovaiDB(self.db).get_value(changed_dict)
+
+        super().callback(new_msg)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requirements = [
 
 setuptools.setup(
     name="gd-node",
-    version="3.0.1-1",
+    version="3.0.1-0",
     author="Backend team",
     author_email="backend@mov.ai",
     description="GD_Node",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [
     "aiohttp_cors==0.7.0",
     "bleach==4.1.0",
     "uvloop==0.14.0",
-    "data-access-layer==3.0.0.*",
+    "data-access-layer==3.0.*",
 ]
 # requests is required by movai-core-shared
 # aioredis is required by data-access-layer

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requirements = [
 
 setuptools.setup(
     name="gd-node",
-    version="3.0.0-2",
+    version="3.0.1-1",
     author="Backend team",
     author_email="backend@mov.ai",
     description="GD_Node",


### PR DESCRIPTION
The class is only used by the gd_node, since it's a feature used by the nodes. Despite using the DAL
for communication with Redis, there's no reason
to keep it there, as no other DAL client needs it.

PR deleting it from the DAL: https://github.com/MOV-AI/data-access-layer/pull/261

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
