### PR TITLE
BP-1330: Implement Async Callbacks

### DIFF
--- a/gd_node/callback.py
+++ b/gd_node/callback.py
@@ -10,9 +10,10 @@
 import sys
 import copy
 import time
+import inspect
 import importlib
 from os import getenv
-from typing import Any
+from typing import Any, Optional
 from asyncio import CancelledError
 
 from rospy.exceptions import ROSException
@@ -133,6 +134,109 @@ class GD_Callback:
                     self.name,
                 )
             exec(code, globais)
+            if "start" in globais and inspect.iscoroutinefunction(globais["start"]):
+                globais["start"]()
+            t_delta = time.perf_counter() - t_init
+            if t_delta > 0.5:
+                LOGGER.debug(
+                    f"{self.node_name}/{self.port_name}/{self.callback.Label} took: {t_delta}"
+                )
+        except TransitionException:
+            LOGGER.debug("Transitioning...")
+            gd.is_transitioning = True
+        except CancelledError:
+            raise CancelledError("cancelled task")
+        except KeyboardInterrupt:
+            LOGGER.warning(f"[KILLED] Callback forcefully killed (node: {self.node_name}, callback={self.name})")
+            sys.exit(1)
+        except Exception:
+            LOGGER.error(
+                f"Error in executing callback. Node: {self.node_name} Callback: {self.name}",
+                exc_info=True,
+            )
+            # TODO We can't kill the node if callbacks blow up. Some callbacks are not critical.
+            # sys.exit(1)
+
+
+class AsyncCallback:
+    """Callback class used to execute user code
+
+    Args:
+        _cb_name: The name of the callback
+        _node_name: The name of the node instance
+        _port_name: The name of the input port
+        _update: Real time update of the callback code
+    """
+
+    _robot = None
+    _scene = None
+
+    def __init__(
+        self, _cb_name: str, _node_name: str, _port_name: str, _update: bool = False
+    ) -> None:
+        """Init"""
+        self.name = _cb_name
+        self.node_name = _node_name
+        self.port_name = _port_name
+        self.updated_globals = {}
+
+        self.callback = ScopesTree().from_path(_cb_name, scope="Callback")
+
+        self.compiled_code = compile(self.callback.Code, _cb_name, "exec")
+        self.user = UserFunctions(
+            _cb_name,
+            _node_name,
+            _port_name,
+            self.callback.Py3Lib,
+            self.callback.Message,
+        )
+        self.count = 0
+
+        self._debug = eval(getenv("DEBUG_CB", "False"))
+
+    async def execute(self, msg: Any = None) -> None:
+        """Executes the code
+
+        Args:
+            msg: Message received in the callback
+        Returns:
+            Result from the callback function, if any
+        """
+
+        self.user.globals.update({"msg": msg})
+        self.user.globals.update({"count": self.count})
+        globais = copy.copy(self.user.globals)
+        await self.start(self.compiled_code, globais)
+        self.count += 1
+        self.updated_globals = globais
+        if (
+            "response" in globais
+            and isinstance(globais["response"], dict)
+            and "status_code" in globais["response"]
+        ):
+            self.updated_globals["status_code"] = globais["response"]["status_code"]
+            del globais["response"]["status_code"]
+
+    async def start(self, code, globais):
+        """Executes the code
+
+        Args:
+            msg: Message received in the callback
+        """
+        try:
+            t_init = time.perf_counter()
+            if self._debug:
+                import linecache
+
+                linecache.cache[self.name] = (
+                    len(self.callback.Code),
+                    None,
+                    self.callback.Code.splitlines(True),
+                    self.name,
+                )
+            exec(code, globais)
+            if "start" in globais and inspect.iscoroutinefunction(globais["start"]):
+                globais["response"] = await globais["start"]()
             t_delta = time.perf_counter() - t_init
             if t_delta > 0.5:
                 LOGGER.debug(


### PR DESCRIPTION
In order to efficiently wait for a callback to execute and return (which may involve waiting for network calls, etc), we implement a way for callbacks to be have async code. The callback should implement an async function named 'start', which will be called right after the code is loaded

Ticket: [BP-1330](https://movai.atlassian.net/browse/BP-1330)

Used by https://github.com/MOV-AI/backend/pull/254/


- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
~~- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue~~


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository


[BP-1330]: https://movai.atlassian.net/browse/BP-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ