### PR TITLE
BP-1360: Migrate enterprise model loading to DAL callback

### DIFF
--- a/gd_node/callback.py
+++ b/gd_node/callback.py
@@ -6,22 +6,6 @@ from movai_core_shared.exceptions import DoesNotExist
 
 from gd_node.user import GD_User as gd
 
-try:
-
-    from movai_core_enterprise.message_client_handlers.alerts import Alerts
-    from movai_core_enterprise.models.annotation import Annotation
-    from movai_core_enterprise.models.graphicasset import GraphicAsset
-    from movai_core_enterprise.models.graphicscene import GraphicScene
-    from movai_core_enterprise.models.layout import Layout
-    from movai_core_enterprise.scopes.task import Task
-    from movai_core_enterprise.models.taskentry import TaskEntry
-    from movai_core_enterprise.models.tasktemplate import TaskTemplate
-    from movai_core_enterprise.message_client_handlers.metrics import Metrics
-
-    enterprise = True
-except ImportError:
-    enterprise = False
-
 
 class GD_Callback(Callback):
     def set_transitioning(self):
@@ -77,18 +61,3 @@ class GD_UserFunctions(UserFunctions):
 
         if _user == "SUPER":
             self.globals["SM"] = UserSM
-            if enterprise:
-                metrics = Metrics()
-                self.globals.update(
-                    {
-                        "Alerts": Alerts,
-                        "Annotation": Annotation,
-                        "GraphicAsset": GraphicAsset,
-                        "GraphicScene": GraphicScene,
-                        "Layout": Layout,
-                        "metrics": metrics,
-                        "Task": Task,
-                        "TaskEntry": TaskEntry,
-                        "TaskTemplate": TaskTemplate,
-                    }
-                )


### PR DESCRIPTION
The loading of enterprise models to callbacks was kept in GD-Node, but that's an error because:

1) Backend callbacks require enterprise models like Metrics, so they need to be available outside of GD-Node
2) movai-core-enterprise doesn't depend on gd-node, so there's no issue in loading it in the DAL

Ticket: [BP-1360](https://movai.atlassian.net/browse/BP-1360)

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
